### PR TITLE
Fix issue / update dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  cached_network_image: ^0.8.0
+  cached_network_image: ^1.1.1
 
 
 


### PR DESCRIPTION
Because circular_profile_avatar 0.2.0 depends on cached_network_image ^0.8.0 and no versions of circular_profile_avatar match >0.2.0 <0.3.0, circular_profile_avatar ^0.2.0 requires cached_network_image ^0.8.0