### PR TITLE
Fixed crash on web with Flutter 3.27.0

### DIFF
--- a/lib/circular_profile_avatar.dart
+++ b/lib/circular_profile_avatar.dart
@@ -1,6 +1,7 @@
 library circular_profile_avatar;
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -167,6 +168,7 @@ class _CircularProfileAvatarState extends State<CircularProfileAvatar> {
             child: CachedNetworkImage(
               fit: widget.imageFit,
               imageUrl: widget.imageUrl,
+              imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
               errorWidget: widget.errorWidget,
               placeholder: widget.placeHolder,
               imageBuilder: widget.imageBuilder,


### PR DESCRIPTION
In reference to 
https://github.com/Baseflow/flutter_cached_network_image/issues/995